### PR TITLE
show percentage when hovering over sectors of a pie chart in ranges&terms panel

### DIFF
--- a/src/app/panels/ranges/module.js
+++ b/src/app/panels/ranges/module.js
@@ -374,7 +374,8 @@ function (angular, app, _, $, kbn) {
             $tooltip
               .html(
                 kbn.query_color_dot(item.series.color, 20) + ' ' +
-                item.series.label + " (" + value.toFixed(0)+")"
+                item.series.label + " (" + value.toFixed(0) +
+                (scope.panel.chart === 'pie' ? (", " + Math.round(item.datapoint[0]) + "%") : "") + ")"
               )
               .place_tt(pos.pageX, pos.pageY);
           } else {

--- a/src/app/panels/terms/module.js
+++ b/src/app/panels/terms/module.js
@@ -407,7 +407,8 @@ function (angular, app, _, $, kbn) {
             $tooltip
               .html(
                 kbn.query_color_dot(item.series.color, 20) + ' ' +
-                item.series.label + " (" + value.toFixed(0)+")"
+                item.series.label + " (" + value.toFixed(0) +
+                (scope.panel.chart === 'pie' ? (", " + Math.round(item.datapoint[0]) + "%") : "") + ")"
               )
               .place_tt(pos.pageX, pos.pageY);
           } else {


### PR DESCRIPTION
Since percentage of some sectors are hidden in a pie chart, these commits make the pie chart to show percentage of a sector when hovering over it.Like this:
![qq 20150204182726](https://cloud.githubusercontent.com/assets/2291859/6038814/866babac-ac9b-11e4-9cd8-e26406ba0f50.png)
